### PR TITLE
[Fix] 1) update时候未指定chunk_range，导致同一个chunk（月）内后更新的数据会冲掉前面更新的数据。修复：指定c…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = vnpy_arctic
-version = 1.0.0
+version = 1.0.1
 url = https://www.vnpy.com
 license = MIT
 author = Xiaoyou Chen
@@ -28,7 +28,6 @@ classifiers =
 [options]
 packages = find:
 zip_safe = False
-install_requires = [
-    "arctic",
-    "pandas <= 1.0.3"
-]
+install_requires =
+    arctic
+    pandas <= 1.0.3

--- a/vnpy_arctic/arctic_database.py
+++ b/vnpy_arctic/arctic_database.py
@@ -67,7 +67,9 @@ class ArcticDatabase(BaseDatabase):
         table_name = generate_table_name(symbol, bar.exchange, bar.interval)
 
         # 将数据更新到数据库中
-        self.bar_library.update(table_name, df, upsert=True, chunk_size="M")
+        self.bar_library.update(
+            table_name, df, upsert=True, chunk_size="M", chunk_range=DateRange(df.date.min(), df.date.max())
+        )
 
         # 更新K线汇总数据
         info: dict = self.bar_library.get_info(table_name)
@@ -149,7 +151,9 @@ class ArcticDatabase(BaseDatabase):
         table_name = generate_table_name(symbol, tick.exchange)
 
         # 将数据更新到数据库中
-        self.tick_library.update(table_name, df, upsert=True, chunk_size="M")
+        self.tick_library.update(
+            table_name, df, upsert=True, chunk_size="M", chunk_range=DateRange(df.date.min(), df.date.max())
+        )
 
     def load_bar_data(
         self,
@@ -161,7 +165,8 @@ class ArcticDatabase(BaseDatabase):
     ) -> List[BarData]:
         """读取K线数据"""
         table_name = generate_table_name(symbol, exchange, interval)
-        df = self.bar_library.read(table_name, chunk_range=DateRange(start, end))
+        df = self.bar_library.read(
+            table_name, chunk_range=DateRange(start, end))
 
         df.set_index("date", inplace=True)
         df = df.tz_localize(DB_TZ)
@@ -196,7 +201,8 @@ class ArcticDatabase(BaseDatabase):
     ) -> List[TickData]:
         """读取Tick数据"""
         table_name = generate_table_name(symbol, exchange)
-        df = self.tick_library.read(table_name, chunk_range=DateRange(start, end))
+        df = self.tick_library.read(
+            table_name, chunk_range=DateRange(start, end))
 
         df.set_index("date", inplace=True)
         df = df.tz_localize(DB_TZ)


### PR DESCRIPTION
修复两个问题：
- 问题1
  - 做tick回测时发现很多天的数据都丢失了，深入研究后发现其实每个月只保存了最后一天。
  - 经测试发现是因为update的时候未指定chuck_range参数。此时Arctic会用本次update覆盖掉当前chunk的所有数据。
    ![image](https://user-images.githubusercontent.com/18441788/136883290-efc81a97-df74-4a21-8b80-79615699bce2.png)
    ![image](https://user-images.githubusercontent.com/18441788/136883348-48b0639f-c168-4eb2-beb4-15930be6e733.png)
    可以看出未指定chunk_range的update会冲掉前面的数据，只保留了每个月最后一次update的数据。指定后无此问题。
  - 修复：指定chuck_size为更新数据的时间段
  - 测试notebook代码
    ```
      import pandas as pd
      import numpy as np
      from arctic.arctic import Arctic, CHUNK_STORE
      from arctic.date import DateRange
      store = Arctic('localhost')
      store.initialize_library("test", CHUNK_STORE)
      date_ranges = [
          pd.date_range("2021-01-05 09:00", "2021-01-05 15:00", freq='H', name='date'),
          pd.date_range("2021-01-10 09:00", "2021-01-10 10:00", freq='H', name='date'),
          pd.date_range("2021-01-10 13:00", "2021-01-10 15:00", freq='H', name='date'),
          pd.date_range("2021-01-10 11:00", "2021-01-10 12:00", freq='H', name='date'),
          pd.date_range("2021-02-05 09:00", "2021-02-05 15:00", freq='H', name='date'),
          pd.date_range("2021-02-10 09:00", "2021-02-10 15:00", freq='H', name='date'),
      ]
      tslib = store.get_library("test")
      tslib.delete("without_range")
      tslib.delete("with_range")
      for dr in date_ranges:
          df = pd.DataFrame(np.random.rand(len(dr), 1), index=dr, columns=['data'])
          tslib.update("without_range", df, upsert=True, chunk_size="M")
          tslib.update("with_range", df, upsert=True, chunk_size="M", chunk_range=DateRange(dr.min(), dr.max()))
      tslib.read("without_range")
      tslib.read("with_range")
    ```
  
 
- 问题2
  - 安装时报错
    ```
      File "C:\Users\ruiyingwork\anaconda3\envs\vnpy_dev\lib\site-packages\setuptools\dist.py", line 664, in _parse_config_files
        parser.read_file(reader)
      File "C:\Users\ruiyingwork\anaconda3\envs\vnpy_dev\lib\configparser.py", line 717, in read_file
        self._read(f, source)
      File "C:\Users\ruiyingwork\anaconda3\envs\vnpy_dev\lib\configparser.py", line 1110, in _read
        raise e
    configparser.ParsingError: Source contains parsing errors: 'setup.cfg'
            [line 34]: ']\n'
    ```
   - 猜测至少Win10平台下cfg不支持数组格式。
   - 未作跨平台测试。